### PR TITLE
Add nexus-cloudinary and create "APIs" category

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ A list of plugins made by the community.
 - [nexus-shield](https://github.com/Sytten/nexus-shield)
 - [nexus-plugin-shield](https://github.com/lvauvillier/nexus-plugin-shield)
 
+### APIs
+
+- [nexus-cloudinary](https://github.com/talentlessguy/nexus-cloudinary)
+
 ## Contribute
 
 Contributions welcome! Read the [contribution guidelines](CONTRIBUTING.md) first.


### PR DESCRIPTION
Since this list is relatively new, I added a section for API integration and put my library there

https://github.com/talentlessguy/nexus-cloudinary